### PR TITLE
Fixes switched description string in TO_FIELD choices

### DIFF
--- a/hordak/models/statement_csv_import.py
+++ b/hordak/models/statement_csv_import.py
@@ -90,8 +90,8 @@ class TransactionCsvImportColumn(models.Model):
         (None, '-- Do not import --'),
         ('date', 'Date'),
         ('amount', 'Amount'),
-        ('amount_out', 'Amount (money in only)'),
-        ('amount_in', 'Amount (money out only)'),
+        ('amount_out', 'Amount (money out only)'),
+        ('amount_in', 'Amount (money in only)'),
         ('description', 'Description / Notes'),
     )
 


### PR DESCRIPTION
The description of the choices for the TO_FIELD were switched such that incomes have been imported as expenses when using split amounts in CSV data.