### PR TITLE
Extend tests

### DIFF
--- a/hordak/tests/models/test_core.py
+++ b/hordak/tests/models/test_core.py
@@ -23,7 +23,7 @@ class AccountTestCase(DataProvider, TransactionTestCase):
         account1 = self.account(code='5')
         account2 = self.account(parent=account1, name='Account 2', code='1')
         account2.refresh_from_db()
-        self.assertEqual(str(account2), '51 Account 2 [€\xa00.00]')
+        self.assertEqual(str(account2).replace('\xa0',' '), '51 Account 2 [€ 0.00]')
 
     def test_str_root_no_data_unsaved(self):
         account1 = Account()

--- a/hordak/tests/models/test_core.py
+++ b/hordak/tests/models/test_core.py
@@ -23,7 +23,7 @@ class AccountTestCase(DataProvider, TransactionTestCase):
         account1 = self.account(code='5')
         account2 = self.account(parent=account1, name='Account 2', code='1')
         account2.refresh_from_db()
-        self.assertEqual(str(account2), '51 Account 2 [€0.00]')
+        self.assertEqual(str(account2), '51 Account 2 [€\xa00.00]')
 
     def test_str_root_no_data_unsaved(self):
         account1 = Account()

--- a/hordak/tests/models/test_core.py
+++ b/hordak/tests/models/test_core.py
@@ -23,7 +23,7 @@ class AccountTestCase(DataProvider, TransactionTestCase):
         account1 = self.account(code='5')
         account2 = self.account(parent=account1, name='Account 2', code='1')
         account2.refresh_from_db()
-        self.assertEqual(str(account2).replace('\xa0',' '), '51 Account 2 [€ 0.00]')
+        self.assertEqual(str(account2).replace('\xa0',''), '51 Account 2 [€0.00]')
 
     def test_str_root_no_data_unsaved(self):
         account1 = Account()

--- a/hordak/tests/test_resources.py
+++ b/hordak/tests/test_resources.py
@@ -11,7 +11,7 @@ from hordak.tests.utils import DataProvider
 
 
 class StatementLineResourceTestCase(DataProvider, TestCase):
-    """Test the resource definition in resources.py"""
+    """Test the resource definition in test_resources.py"""
 
     def setUp(self):
         self.account = self.account(is_bank_account=True, type=Account.TYPES.asset)
@@ -122,11 +122,12 @@ class StatementLineResourceTestCase(DataProvider, TestCase):
         dataset = tablib.Dataset(
             ['15/6/2016', '', '100.56', 'Example payment'],
             ['16/6/2016', '60.31', '', 'Example income'],
+            ['17/6/2016', '', '-102.56', 'Example payment 2'],
             headers=['date', 'amount_in', 'amount_out', 'description']
         )
         self.makeResource().import_data(dataset)
 
-        self.assertEqual(StatementLine.objects.count(), 2)
+        self.assertEqual(StatementLine.objects.count(), 3)
 
         obj = StatementLine.objects.all().order_by('date')
         self.assertEqual(obj[0].date, date(2016, 6, 15))
@@ -136,6 +137,10 @@ class StatementLineResourceTestCase(DataProvider, TestCase):
         self.assertEqual(obj[1].date, date(2016, 6, 16))
         self.assertEqual(obj[1].amount, Decimal('60.31'))
         self.assertEqual(obj[1].description, 'Example income')
+
+        self.assertEqual(obj[2].date, date(2016, 6, 17))
+        self.assertEqual(obj[2].amount, Decimal('-102.56'))
+        self.assertEqual(obj[2].description, 'Example payment 2')
 
     def test_error_no_date(self):
         dataset = tablib.Dataset(


### PR DESCRIPTION
First commit accounts for the protected space between currency and amount if converting a Balance to string. Tests failed before that.

Second one renames a test file to have the test_ prefix and extends the split amount test case.