### PR TITLE
Improvements to ratio_split()

### DIFF
--- a/hordak/tests/utilities/test_money.py
+++ b/hordak/tests/utilities/test_money.py
@@ -3,15 +3,27 @@ from decimal import Decimal
 from django.test import TestCase
 from hordak.utilities.money import ratio_split
 
+# Note: these tests assume that sorting is stable across all Python versions.
 
 class RatioSplitTestCase(TestCase):
     def test_extra_penny(self):
         values = ratio_split(Decimal("10"), [Decimal("3"), Decimal("3"), Decimal("3")])
-        self.assertEqual(values, [Decimal("3.33"), Decimal("3.33"), Decimal("3.34")])
+        self.assertEqual(values, [Decimal('3.34'), Decimal('3.33'), Decimal('3.33')])
 
     def test_less_penny(self):
         values = ratio_split(Decimal("8"), [Decimal("3"), Decimal("3"), Decimal("3")])
-        self.assertEqual(values, [Decimal("2.67"), Decimal("2.67"), Decimal("2.66")])
+        self.assertEqual(values, [Decimal('2.66'), Decimal('2.67'), Decimal('2.67')])
+
+    def test_pennies(self):
+        values = ratio_split(Decimal("-11.06"), [Decimal("1"), Decimal("1"), Decimal("1"), Decimal("1")])
+        self.assertEqual(values, [Decimal("-2.77"), Decimal("-2.77"), Decimal("-2.76"), Decimal("-2.76")])
+
+    def test_pennies_zeros(self):
+        values = ratio_split(Decimal("11.05"), [Decimal("1"), Decimal("1"), Decimal("0")])
+        self.assertEqual(values, [Decimal('5.53'), Decimal('5.52'), Decimal('0.00')])
+
+        values = ratio_split(Decimal("11.05"), [Decimal("0"), Decimal("1"), Decimal("1")])
+        self.assertEqual(values, [Decimal('0.00'), Decimal('5.53'), Decimal('5.52')])
 
     def test_all_equal(self):
         values = ratio_split(Decimal("30"), [Decimal("3"), Decimal("3"), Decimal("3")])


### PR DESCRIPTION
The current implementation of `ratio_split()` distributes any change left after rounding to the last participant.

This causes two minor issues:
- participants with a `ratio == 0` may still end up receiving change (debit or credit)
- the distribution of change is not fair, eg. one participant may end up paying 0.03 more instead of having three participants pay 0.01 more.

This PR fixes this by using the Largest Remainder method to allocate change between participants with a `ratio != 0`.

It also fixes a further problem whereby `ratio_split()` assumed `DECIMAL_PLACES=2`.