### PR TITLE
don't hold django-import-export anymore

### DIFF
--- a/hordak/resources.py
+++ b/hordak/resources.py
@@ -66,7 +66,7 @@ class StatementLineResource(resources.ModelResource):
         instance._row = row
         return instance
 
-    def skip_row(self, instance, original):
+    def skip_row(self, instance, original, *args, **kwargs):
         # Skip this row if the database already contains the requsite number of
         # rows identical to this one.
         return instance._row["similar_total"] < self._get_num_similar_objects(instance)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ django-extensions>=1.7.3
 django-smalluuid>=1.2.1
 requests>=2
 django-money>=0.9.1
-django-import-export>=0.5.0,<3.0.0  # Version 3.0.0 might have some incompatibilities, so we use a lower version until it is released
+django-import-export>=0.5.0
 babel>=2.9.1
 openpyxl<=2.6;python_version<"3.5"


### PR DESCRIPTION
Pull this once `django-import-export` 3.0.0 is released and all tests are passing.