### PR TITLE
Fixing `transfer_to` for Liability -> Cash account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ static/
 /build
 /dist
 /transaction_imports
+
+pyproject.toml
+poetry.lock

--- a/hordak/models/core.py
+++ b/hordak/models/core.py
@@ -330,7 +330,7 @@ class Account(MPTTModel):
             # (which is opposite to the implicit behaviour)
             direction = -1
         elif (
-            self.type == self.TYPES.liability and to_account.type == self.TYPES.expense
+            self.type == self.TYPES.liability and to_account.type in [self.TYPES.expense, self.TYPES.asset]
         ):
             # Transfers from liability -> asset accounts should reduce both.
             # For example, moving money from Rent Payable (liability) to your Rent (expense) account

--- a/hordak/tests/models/test_core.py
+++ b/hordak/tests/models/test_core.py
@@ -371,6 +371,25 @@ class AccountTestCase(DataProvider, DbTransactionTestCase):
         self.assertEqual(dst.balance(), Balance(100, "EUR"))
         Account.validate_accounting_equation()
 
+    def test_transfer_liability_to_asset(self):
+        # When doing this it is probably safe to assume we want to the
+        # liability account to contribute to an asset (i.e. cash), therefore both should decrease
+        src = self.account(type=Account.TYPES.liability)
+        dst = self.account(type=Account.TYPES.asset)
+        src.transfer_to(dst, Money(100, "EUR"))
+        self.assertEqual(src.balance(), Balance(-100, "EUR"))
+        self.assertEqual(dst.balance(), Balance(-100, "EUR"))
+        Account.validate_accounting_equation()
+
+    def test_transfer_asset_to_liability(self):
+        # This should perform the reverse action to that in the above test_transfer_liability_to_asset()
+        src = self.account(type=Account.TYPES.asset)
+        dst = self.account(type=Account.TYPES.liability)
+        src.transfer_to(dst, Money(100, "EUR"))
+        self.assertEqual(src.balance(), Balance(100, "EUR"))
+        self.assertEqual(dst.balance(), Balance(100, "EUR"))
+        Account.validate_accounting_equation()
+
     def test_currency_exchange(self):
         src = self.account(type=Account.TYPES.asset, currencies=["GBP"])
         trading = self.account(type=Account.TYPES.trading, currencies=["GBP", "EUR"])


### PR DESCRIPTION
The function `transfer_to`'s description, in the comments, is correct. It says:

> Transfers from liability -> asset accounts should reduce both.

but in reality that only happens for expense accounts.

Adding Asset accounts to that.

----------------------------

@PetrDlouhy there were a few other specs that were failing, but I didn't touch them because they look like display bugs for the app and I'm unsure as to what the "spirit" of those were supposed to be.

```
======================================================================
FAIL: test_get (hordak.tests.views.test_accounts.AccountTransactionsViewTestCase.test_get)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/justin/dev/kaukau/django-hordak/hordak/tests/views/test_accounts.py", line 32, in test_get
    self.assertContains(response, "<h5>Balance: €&nbsp;10.00</h5>", html=True)
  File "/Users/justin/dev/kaukau/django-hordak/.venv/lib/python3.11/site-packages/django/test/testcases.py", line 660, in assertContains
    self.assertTrue(
AssertionError: False is not true : Couldn't find '<h5>Balance: €&nbsp;10.00</h5>' in response

======================================================================
FAIL: test_str_currency (hordak.tests.models.test_core.AccountTestCase.test_str_currency)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/justin/dev/kaukau/django-hordak/hordak/tests/models/test_core.py", line 61, in test_str_currency
    self.assertEqual(str(account), "0 Account 1 [€\xa00.00, £\xa00.00]")
AssertionError: '0 Account 1 [€0.00, £0.00]' != '0 Account 1 [€\xa00.00, £\xa00.00]'
- 0 Account 1 [€0.00, £0.00]
+ 0 Account 1 [€ 0.00, £ 0.00]
?               +       +


======================================================================
FAIL: test_str_currency_no_full_code (hordak.tests.models.test_core.AccountTestCase.test_str_currency_no_full_code)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/justin/dev/kaukau/django-hordak/hordak/tests/models/test_core.py", line 66, in test_str_currency_no_full_code
    self.assertEqual(str(account), "Account 1 [€\xa00.00, £\xa00.00]")
AssertionError: 'Account 1 [€0.00, £0.00]' != 'Account 1 [€\xa00.00, £\xa00.00]'
- Account 1 [€0.00, £0.00]
+ Account 1 [€ 0.00, £ 0.00]
?             +       +
```