### PR TITLE
Unicode spec fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,5 @@ static/
 pyproject.toml
 poetry.lock
 .vscode
-pytest.ini
 
 .coverage

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+Version 1.14.0,
+===============================
+
+* Now using Django's locale to `Balance.__str__`'s `format_money` allowing better formatting and specs.
+
 Version 1.13.0, Fri 17 Feb 2023
 ===============================
 
@@ -351,5 +356,3 @@ Version 1.0.1, Fri 16 Sep 2016
 
 Version 1.0.0 (first version), Tue 13 Sep 2016
 ===============================================
-
-

--- a/hordak/templatetags/hordak.py
+++ b/hordak/templatetags/hordak.py
@@ -6,6 +6,7 @@ from decimal import Decimal
 import babel.numbers
 from django import template
 from django.utils.safestring import mark_safe
+from django.utils.translation import get_language, to_locale
 from moneyed import Money
 
 from hordak.utilities.currency import Balance
@@ -29,6 +30,8 @@ def inv(value):
 
 @register.filter()
 def currency(value):
+    locale = to_locale(get_language())
+
     if value is None:
         return None
 
@@ -36,14 +39,14 @@ def currency(value):
         locale_values = []
         for money in value.monies():
             locale_value = babel.numbers.format_currency(
-                abs(money.amount), currency=money.currency.code
+                abs(money.amount), currency=money.currency.code, locale=locale
             )
             locale_value = (
                 locale_value if money.amount >= 0 else "({})".format(locale_value)
             )
             locale_values.append(locale_value)
     else:
-        locale_value = babel.numbers.format_decimal(abs(value))
+        locale_value = babel.numbers.format_decimal(abs(value), locale=locale)
         locale_value = locale_value if value >= 0 else "({})".format(locale_value)
         locale_values = [locale_value]
 

--- a/hordak/tests/models/test_core.py
+++ b/hordak/tests/models/test_core.py
@@ -58,12 +58,12 @@ class AccountTestCase(DataProvider, DbTransactionTestCase):
 
     def test_str_currency(self):
         account = self.account(currencies=["EUR", "GBP"])
-        self.assertEqual(str(account), "0 Account 1 [€\xa00.00, £\xa00.00]")
+        self.assertEqual(str(account).replace("\xa0", ""), "0 Account 1 [€0.00, £0.00]")
 
     def test_str_currency_no_full_code(self):
         account = self.account(currencies=["EUR", "GBP"])
         account.full_code = None
-        self.assertEqual(str(account), "Account 1 [€\xa00.00, £\xa00.00]")
+        self.assertEqual(str(account).replace("\xa0", ""), "Account 1 [€0.00, £0.00]")
 
     def test_str_non_existent_currency(self):
         """__str__ should not fail even if the currency doesn't exist"""

--- a/hordak/tests/models/test_core.py
+++ b/hordak/tests/models/test_core.py
@@ -57,8 +57,11 @@ class AccountTestCase(DataProvider, DbTransactionTestCase):
             )
 
     def test_str_currency(self):
+        from django.utils.translation import activate
+
+        activate("en-SG")
         account = self.account(currencies=["EUR", "GBP"])
-        self.assertEqual(str(account).replace("\xa0", ""), "0 Account 1 [€0.00, £0.00]")
+        self.assertEqual(str(account), "0 Account 1 [€0.00, £0.00]")
 
     def test_str_currency_no_full_code(self):
         account = self.account(currencies=["EUR", "GBP"])

--- a/hordak/tests/templatetags/test_hordak.py
+++ b/hordak/tests/templatetags/test_hordak.py
@@ -1,0 +1,25 @@
+from decimal import Decimal
+
+from django.test import TestCase
+from django.utils.translation import activate, get_language, to_locale
+from moneyed import Money
+
+from hordak.templatetags.hordak import currency
+from hordak.utilities.currency import Balance
+
+
+class TestHordakTemplateTags(TestCase):
+    def setUp(self):
+        self.orig_locale = to_locale(get_language())
+        activate("en-US")
+
+    def tearDown(self):
+        activate(self.orig_locale)
+
+    def test_currency_as_balance(self):
+        bal = Balance([Money("10.00", "EUR")])
+        assert currency(bal) == "€10.00"
+
+    def test_currency_as_val(self):
+        bal = Decimal(10000)
+        assert currency(bal) == "10,000"

--- a/hordak/tests/views/test_accounts.py
+++ b/hordak/tests/views/test_accounts.py
@@ -29,7 +29,10 @@ class AccountTransactionsViewTestCase(DataProvider, TestCase):
         response = self.client.get(self.view_url)
         # Tests needs to be run with LANG="US" environment variable
         self.assertContains(response, "<td>€10.00</td>", html=True)
-        self.assertContains(response, "<h5>Balance: €&nbsp;10.00</h5>", html=True)
+        self.assertRegex(
+            str(response.content.decode("utf-8")).replace("\xa0", ""),
+            r"<h5>Balance: €10.00</h5>",
+        )
 
 
 class AccountListViewTestCase(DataProvider, TestCase):

--- a/hordak/tests/views/test_accounts.py
+++ b/hordak/tests/views/test_accounts.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 from django.urls import reverse
+from django.utils.translation import activate, get_language, to_locale
 
 from hordak.forms.accounts import AccountForm
 from hordak.models import Account, Leg, Transaction
@@ -25,14 +26,16 @@ class AccountTransactionsViewTestCase(DataProvider, TestCase):
         )
         self.login()
 
+        self.orig_locale = to_locale(get_language())
+        activate("en-US")
+
+    def tearDown(self):
+        activate(self.orig_locale)
+
     def test_get(self):
         response = self.client.get(self.view_url)
-        # Tests needs to be run with LANG="US" environment variable
         self.assertContains(response, "<td>€10.00</td>", html=True)
-        self.assertRegex(
-            str(response.content.decode("utf-8")).replace("\xa0", ""),
-            r"<h5>Balance: €10.00</h5>",
-        )
+        self.assertContains(response, "<h5>Balance: €10.00</h5>", html=True)
 
 
 class AccountListViewTestCase(DataProvider, TestCase):

--- a/hordak/utilities/currency.py
+++ b/hordak/utilities/currency.py
@@ -428,8 +428,12 @@ class Balance(object):
 
     def __str__(self):
         def fmt(money):
+            from django.utils.translation import get_language, to_locale
+
+            locale = to_locale(get_language())
+
             return babel.numbers.format_currency(
-                money.amount, currency=money.currency.code
+                money.amount, currency=money.currency.code, locale=locale
             )
 
         return ", ".join(map(fmt, self._money_obs)) or "No values"

--- a/hordak/utilities/currency.py
+++ b/hordak/utilities/currency.py
@@ -55,6 +55,7 @@ import babel.numbers
 import requests
 from django.core.cache import cache
 from django.db import transaction as db_transaction
+from django.utils.translation import get_language, to_locale
 from moneyed import Money
 
 from hordak import defaults
@@ -428,8 +429,6 @@ class Balance(object):
 
     def __str__(self):
         def fmt(money):
-            from django.utils.translation import get_language, to_locale
-
             locale = to_locale(get_language())
 
             return babel.numbers.format_currency(

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+DJANGO_SETTINGS_MODULE=example_project.settings
+addopts=--color=yes --code-highlight=yes
+python_files=test_*.py


### PR DESCRIPTION
Currently these specs fail on OSX (possibly others) due to `babel`'s machine dependent output of spaces as unicode `\xa0`.

Original discussion points:

- https://github.com/adamcharnock/django-hordak/pull/82#issuecomment-1532590208