### PR TITLE
Demonstration of `sleep()` during `lock`

### DIFF
--- a/hordak/receivers.py
+++ b/hordak/receivers.py
@@ -1,3 +1,5 @@
+from time import sleep
+
 from django.db import connection
 from django.db.models import F
 from django.db.models.signals import post_delete, pre_save
@@ -23,6 +25,8 @@ def update_running_totals(sender, instance, **kwargs):
     amount_change = instance.account.sign * amount_change
     with connection.cursor() as cursor:
         cursor.execute("LOCK TABLE %s IN EXCLUSIVE MODE" % RunningTotal._meta.db_table)
+
+        sleep(2)
 
         running_total, created = RunningTotal.objects.get_or_create(
             account=instance.account,

--- a/hordak/tests/models/test_core.py
+++ b/hordak/tests/models/test_core.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from django.db import transaction as db_transaction
 from django.db.utils import DatabaseError, IntegrityError
 from django.test.testcases import TransactionTestCase as DbTransactionTestCase
-from django.utils.translation import activate, get_language, to_locale
 from moneyed.classes import Money
 
 from hordak import exceptions
@@ -19,21 +18,14 @@ from hordak.models import (
     StatementLine,
     Transaction,
 )
-from hordak.tests.utils import DataProvider
+from hordak.tests.utils import DataProvider, TestLocaleMixin
 from hordak.utilities.currency import Balance
 
 
 warnings.simplefilter("ignore", category=DeprecationWarning)
 
 
-class AccountTestCase(DataProvider, DbTransactionTestCase):
-    def setUp(self):
-        self.orig_locale = to_locale(get_language())
-        activate("en-US")
-
-    def tearDown(self):
-        activate(self.orig_locale)
-
+class AccountTestCase(TestLocaleMixin, DataProvider, DbTransactionTestCase):
     def test_str_root(self):
         # Account code should not be rendered as we should not
         # associate transaction legs with non-leaf accounts

--- a/hordak/tests/templatetags/test_hordak.py
+++ b/hordak/tests/templatetags/test_hordak.py
@@ -1,21 +1,14 @@
 from decimal import Decimal
 
 from django.test import TestCase
-from django.utils.translation import activate, get_language, to_locale
 from moneyed import Money
 
 from hordak.templatetags.hordak import currency
+from hordak.tests.utils import TestLocaleMixin
 from hordak.utilities.currency import Balance
 
 
-class TestHordakTemplateTags(TestCase):
-    def setUp(self):
-        self.orig_locale = to_locale(get_language())
-        activate("en-US")
-
-    def tearDown(self):
-        activate(self.orig_locale)
-
+class TestHordakTemplateTags(TestLocaleMixin, TestCase):
     def test_currency_as_balance(self):
         bal = Balance([Money("10.00", "EUR")])
         assert currency(bal) == "€10.00"

--- a/hordak/tests/test_commands.py
+++ b/hordak/tests/test_commands.py
@@ -7,7 +7,7 @@ from django.test.testcases import TransactionTestCase as DbTransactionTestCase
 from moneyed.classes import Money
 
 from hordak.models import Account, Leg, RunningTotal, Transaction
-from hordak.tests.utils import DataProvider
+from hordak.tests.utils import DataProvider, TestLocaleMixin
 
 
 class CreateChartOfAccountsTestCase(TestCase):
@@ -25,7 +25,9 @@ class CreateChartOfAccountsTestCase(TestCase):
 
 
 @override_settings(ADMINS=[("Admin", "foo@bar.cz")])
-class RecalculateRunningTotalsTestCase(DataProvider, DbTransactionTestCase):
+class RecalculateRunningTotalsTestCase(
+    TestLocaleMixin, DataProvider, DbTransactionTestCase
+):
     def test_simple(self):
         account1 = self.account()
         account2 = self.account()
@@ -112,7 +114,7 @@ class RecalculateRunningTotalsTestCase(DataProvider, DbTransactionTestCase):
         self.assertEqual(
             ret_val,
             "Running totals are INCORRECT: \n\n"
-            "Account Account 1 has faulty running total for EUR (should be € 100.00, is €200.00)\n",
+            "Account Account 1 has faulty running total for EUR (should be €100.00, is €200.00)\n",
         )
 
     def test_mail_admins(self):
@@ -141,7 +143,7 @@ class RecalculateRunningTotalsTestCase(DataProvider, DbTransactionTestCase):
         self.assertEqual(
             ret_val,
             "Running totals are INCORRECT: \n\n"
-            "Account Account 1 has faulty running total for EUR (should be € 100.00, is €200.00)\n",
+            "Account Account 1 has faulty running total for EUR (should be €100.00, is €200.00)\n",
         )
         self.assertEqual(len(mail.outbox), 1)
         self.assertEqual(
@@ -150,5 +152,5 @@ class RecalculateRunningTotalsTestCase(DataProvider, DbTransactionTestCase):
         self.assertEqual(
             mail.outbox[0].body,
             "Running totals are incorrect for some accounts\n\n"
-            "Account Account 1 has faulty running total for EUR (should be € 100.00, is €200.00)\n",
+            "Account Account 1 has faulty running total for EUR (should be €100.00, is €200.00)\n",
         )

--- a/hordak/tests/utils.py
+++ b/hordak/tests/utils.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import User
+from django.utils.translation import activate, get_language, to_locale
 
 from hordak.models import Account, StatementImport
 from hordak.utilities.currency import Balance
@@ -96,3 +97,16 @@ class BalanceUtils(object):
         ), "Can only compare balances which contain a single currency"
         balance_amount = balance.monies()[0].amount
         assert balance_amount == value, "Balance {} != {}".format(balance_amount, value)
+
+
+class TestLocaleMixin:
+    def setUp(self):
+        self.orig_locale = to_locale(get_language())
+        activate("en-US")
+
+        super().setUp()
+
+    def tearDown(self):
+        activate(self.orig_locale)
+
+        super().tearDown()

--- a/hordak/tests/views/test_accounts.py
+++ b/hordak/tests/views/test_accounts.py
@@ -1,13 +1,12 @@
 from django.test import TestCase
 from django.urls import reverse
-from django.utils.translation import activate, get_language, to_locale
 
 from hordak.forms.accounts import AccountForm
 from hordak.models import Account, Leg, Transaction
-from hordak.tests.utils import DataProvider
+from hordak.tests.utils import DataProvider, TestLocaleMixin
 
 
-class AccountTransactionsViewTestCase(DataProvider, TestCase):
+class AccountTransactionsViewTestCase(TestLocaleMixin, DataProvider, TestCase):
     def setUp(self):
         self.bank_account = self.account(is_bank_account=True, type=Account.TYPES.asset)
         self.income_account = self.account(
@@ -26,11 +25,7 @@ class AccountTransactionsViewTestCase(DataProvider, TestCase):
         )
         self.login()
 
-        self.orig_locale = to_locale(get_language())
-        activate("en-US")
-
-    def tearDown(self):
-        activate(self.orig_locale)
+        super().setUp()
 
     def test_get(self):
         response = self.client.get(self.view_url)


### PR DESCRIPTION
Sorry for the locale updates, just making it pass locally and in github flows.

The important part is the `sleep(2)`.