### PR TITLE
Add MySQL changelog to support and fix MySQL CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         ports:
           - 5432:5432
       mariadb:
-        image: mariadb
+        image: mariadb:10.5.21
         env:
           MARIADB_DATABASE: mariadb
           MYSQL_ALLOW_EMPTY_PASSWORD: yes

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,8 @@ Version 1.14.0,
       * `Fixtures`
     * Previous: `EUR, USD` => `["EUR", "USD"]`
     * Form complains if it is not valid JSON and returns an explanation.
+* MySQL support
+  * Migrations and triggers modified to target MySQL whilst maintaining compatibility with postgres
 
 Version 1.13.0, Fri 17 Feb 2023
 ===============================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,10 +23,10 @@ Hordak is ``tested against``:
 
  * Django >= 2.2, <= 4.0
  * Python >= 3.6
- * Postgres >= 9.5
+ * Postgres >= 9.5 or MariaDB >= 10.5 (MySQL >= 8.0)
 
-Postgres is required, MySQL is unsupported. This is due to the database constraints we apply to
-ensure data integrity. MySQL could be certainly supported in future, volunteers welcome.
+Postgres or MariaDB / MySQL are required (MySQL support as of Hordak 1.14.0). Other databases (e.g. SQLite) are unsupported. This is due to the database constraints we apply to
+ensure data integrity. Others may be supported in future, volunteers welcome.
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
* MySQL support mentioned in CHANGES.txt
* Docs updated to mention MySQL is now supported but mention other databases won't work because custom triggers needed (in case someone expects it to work on [other databases that Django supports](https://docs.djangoproject.com/en/4.2/ref/databases/)
* Workaround Github actions CI failing after MariaDB updated their docker image (healthcheck which determines whether MariaDB is running has changed so will need to investigate, but there may be some merit in pinning to a specific version anyway)