### PR TITLE
Removing transfer_to() and replacing it with accounting_transfer_to()

### DIFF
--- a/hordak/forms/transactions.py
+++ b/hordak/forms/transactions.py
@@ -21,17 +21,17 @@ class SimpleTransactionForm(forms.ModelForm):
         * :meth:`hordak.models.Account.transfer_to()`.
     """
 
-    from_account = TreeNodeChoiceField(
-        queryset=Account.objects.all(), to_field_name="uuid"
+    debit_account = TreeNodeChoiceField(
+        queryset=Account.objects.all(), to_field_name="uuid", label="Debit account"
     )
-    to_account = TreeNodeChoiceField(
-        queryset=Account.objects.all(), to_field_name="uuid"
+    credit_account = TreeNodeChoiceField(
+        queryset=Account.objects.all(), to_field_name="uuid", label="Credit account"
     )
     amount = MoneyField(max_digits=MAX_DIGITS, decimal_places=DECIMAL_PLACES)
 
     class Meta:
         model = Transaction
-        fields = ["amount", "from_account", "to_account", "date", "description"]
+        fields = ["amount", "debit_account", "credit_account", "date", "description"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -49,12 +49,12 @@ class SimpleTransactionForm(forms.ModelForm):
         self.fields["amount"].initial[1] = default_currency
 
     def save(self, commit=True):
-        from_account = self.cleaned_data.get("from_account")
-        to_account = self.cleaned_data.get("to_account")
+        debit_account = self.cleaned_data.get("debit_account")
+        credit_account = self.cleaned_data.get("credit_account")
         amount = self.cleaned_data.get("amount")
 
-        return from_account.transfer_to(
-            to_account=to_account,
+        return debit_account.transfer_to(
+            to_account=credit_account,
             amount=amount,
             description=self.cleaned_data.get("description"),
             date=self.cleaned_data.get("date"),

--- a/hordak/forms/transactions.py
+++ b/hordak/forms/transactions.py
@@ -22,10 +22,10 @@ class SimpleTransactionForm(forms.ModelForm):
     """
 
     debit_account = TreeNodeChoiceField(
-        queryset=Account.objects.all(), to_field_name="uuid", label="Debit account"
+        queryset=Account.objects.all(), to_field_name="uuid"
     )
     credit_account = TreeNodeChoiceField(
-        queryset=Account.objects.all(), to_field_name="uuid", label="Credit account"
+        queryset=Account.objects.all(), to_field_name="uuid"
     )
     amount = MoneyField(max_digits=MAX_DIGITS, decimal_places=DECIMAL_PLACES)
 

--- a/hordak/tests/forms/test_transactions.py
+++ b/hordak/tests/forms/test_transactions.py
@@ -19,8 +19,8 @@ class SimpleTransactionFormTestCase(DataProvider, TestCase):
     def test_valid_data(self):
         form = SimpleTransactionForm(
             dict(
-                from_account=self.from_account.uuid,
-                to_account=self.to_account.uuid,
+                debit_account=self.from_account.uuid,
+                credit_account=self.to_account.uuid,
                 description="A test simple transaction",
                 amount_0="50.00",
                 amount_1="EUR",
@@ -36,23 +36,23 @@ class SimpleTransactionFormTestCase(DataProvider, TestCase):
         self.assertEqual(transaction.legs.count(), 2)
 
         # Account balances changed
-        self.assertEqual(self.from_account.balance(), Balance(-50, "EUR"))
-        self.assertEqual(self.to_account.balance(), Balance(50, "EUR"))
+        self.assertEqual(self.from_account.balance(), Balance(50, "EUR"))
+        self.assertEqual(self.to_account.balance(), Balance(-50, "EUR"))
 
         # Check transaction legs have amounts set as expected
         from_leg = transaction.legs.get(account=self.from_account)
         to_leg = transaction.legs.get(account=self.to_account)
 
-        self.assertEqual(from_leg.amount, Money(-50, "EUR"))
-        self.assertEqual(to_leg.amount, Money(50, "EUR"))
+        self.assertEqual(from_leg.amount, Money(50, "EUR"))
+        self.assertEqual(to_leg.amount, Money(-50, "EUR"))
 
     def test_transfer_from_bank_to_income(self):
         """If we move money out of the bank and into an income account, we expect both values to go up"""
 
         form = SimpleTransactionForm(
             dict(
-                from_account=self.bank.uuid,
-                to_account=self.income.uuid,
+                debit_account=self.bank.uuid,
+                credit_account=self.income.uuid,
                 description="A test simple transaction",
                 amount_0="50.00",
                 amount_1="EUR",
@@ -61,14 +61,14 @@ class SimpleTransactionFormTestCase(DataProvider, TestCase):
         )
         self.assertTrue(form.is_valid())
         form.save()
-        self.assertEqual(self.bank.balance(), Balance(50, "EUR"))
-        self.assertEqual(self.income.balance(), Balance(50, "EUR"))
+        self.assertEqual(self.bank.balance(), Balance(-50, "EUR"))
+        self.assertEqual(self.income.balance(), Balance(-50, "EUR"))
 
     def test_no_from_account(self):
         form = SimpleTransactionForm(
             dict(
-                from_account="",
-                to_account=self.to_account.uuid,
+                debit_account="",
+                credit_account=self.to_account.uuid,
                 description="A test simple transaction",
                 amount_0="50.00",
                 amount_1="EUR",
@@ -80,8 +80,8 @@ class SimpleTransactionFormTestCase(DataProvider, TestCase):
     def test_no_to_account(self):
         form = SimpleTransactionForm(
             dict(
-                from_account=self.from_account.uuid,
-                to_account="",
+                debit_account=self.from_account.uuid,
+                credit_account="",
                 description="A test simple transaction",
                 amount_0="50.00",
                 amount_1="EUR",
@@ -93,8 +93,8 @@ class SimpleTransactionFormTestCase(DataProvider, TestCase):
     def test_no_description_account(self):
         form = SimpleTransactionForm(
             dict(
-                from_account=self.from_account.uuid,
-                to_account=self.to_account.uuid,
+                debit_account=self.from_account.uuid,
+                credit_account=self.to_account.uuid,
                 description="",
                 amount_0="50.00",
                 amount_1="EUR",
@@ -107,8 +107,8 @@ class SimpleTransactionFormTestCase(DataProvider, TestCase):
     def test_no_amount(self):
         form = SimpleTransactionForm(
             dict(
-                from_account=self.from_account.uuid,
-                to_account=self.to_account.uuid,
+                debit_account=self.from_account.uuid,
+                credit_account=self.to_account.uuid,
                 description="A test simple transaction",
                 amount_0="",
                 amount_1="",

--- a/hordak/tests/models/test_core.py
+++ b/hordak/tests/models/test_core.py
@@ -326,19 +326,6 @@ class AccountTestCase(DataProvider, DbTransactionTestCase):
         self.assertEqual(income.simple_balance(), Balance(100, "EUR"))
         self.assertEqual(bank.simple_balance(), Balance(100, "EUR"))
 
-    def test_net_balance(self):
-        bank = self.account(type=AccountType.asset)
-        account1 = self.account(type=AccountType.income)
-        account2 = self.account(type=AccountType.income)
-
-        bank.transfer_to(account1, Money(100, "EUR"))
-        bank.transfer_to(account2, Money(50, "EUR"))
-
-        self.assertEqual(
-            Account.objects.filter(type=AccountType.income).net_balance(),
-            Balance(150, "EUR"),
-        )
-
     def test_zero_balance_single(self):
         account = self.account(currencies=["GBP"])._zero_balance()
         self.assertEqual(account, Balance("0", "GBP"))
@@ -351,69 +338,10 @@ class AccountTestCase(DataProvider, DbTransactionTestCase):
         account = self.account(currencies=[])._zero_balance()
         self.assertEqual(account, Balance())
 
-    def test_transfer_to(self):
-        account1 = self.account(type=AccountType.income)
-        account2 = self.account(type=AccountType.income)
-        transaction = account1.transfer_to(account2, Money(500, "EUR"))
-        self.assertEqual(transaction.legs.count(), 2)
-        self.assertEqual(account1.balance(), Balance(-500, "EUR"))
-        self.assertEqual(account2.balance(), Balance(500, "EUR"))
-
     def test_transfer_to_not_money(self):
         account1 = self.account(type=AccountType.income)
         with self.assertRaisesRegex(TypeError, "amount must be of type Money"):
             account1.transfer_to(account1, 500)
-
-    def test_transfer_pos_to_pos(self):
-        src = self.account(type=AccountType.income)
-        dst = self.account(type=AccountType.income)
-        src.transfer_to(dst, Money(100, "EUR"))
-        self.assertEqual(src.balance(), Balance(-100, "EUR"))
-        self.assertEqual(dst.balance(), Balance(100, "EUR"))
-        Account.validate_accounting_equation()
-
-    def test_transfer_pos_to_neg(self):
-        src = self.account(type=AccountType.income)
-        dst = self.account(type=AccountType.asset)
-        src.transfer_to(dst, Money(100, "EUR"))
-        self.assertEqual(src.balance(), Balance(100, "EUR"))
-        self.assertEqual(dst.balance(), Balance(100, "EUR"))
-        Account.validate_accounting_equation()
-
-    def test_transfer_neg_to_pos(self):
-        src = self.account(type=AccountType.asset)
-        dst = self.account(type=AccountType.income)
-        src.transfer_to(dst, Money(100, "EUR"))
-        self.assertEqual(src.balance(), Balance(100, "EUR"))
-        self.assertEqual(dst.balance(), Balance(100, "EUR"))
-        Account.validate_accounting_equation()
-
-    def test_transfer_neg_to_neg(self):
-        src = self.account(type=AccountType.asset)
-        dst = self.account(type=AccountType.asset)
-        src.transfer_to(dst, Money(100, "EUR"))
-        self.assertEqual(src.balance(), Balance(-100, "EUR"))
-        self.assertEqual(dst.balance(), Balance(100, "EUR"))
-        Account.validate_accounting_equation()
-
-    def test_transfer_liability_to_expense(self):
-        # When doing this it is probably safe to assume we want to the
-        # liability account to contribute to an expense, therefore both should decrease
-        src = self.account(type=AccountType.liability)
-        dst = self.account(type=AccountType.expense)
-        src.transfer_to(dst, Money(100, "EUR"))
-        self.assertEqual(src.balance(), Balance(-100, "EUR"))
-        self.assertEqual(dst.balance(), Balance(-100, "EUR"))
-        Account.validate_accounting_equation()
-
-    def test_transfer_expense_to_liability(self):
-        # This should perform the reverse action to that in the above test_transfer_liability_to_expense()
-        src = self.account(type=AccountType.expense)
-        dst = self.account(type=AccountType.liability)
-        src.transfer_to(dst, Money(100, "EUR"))
-        self.assertEqual(src.balance(), Balance(100, "EUR"))
-        self.assertEqual(dst.balance(), Balance(100, "EUR"))
-        Account.validate_accounting_equation()
 
     def test_currency_exchange(self):
         src = self.account(type=AccountType.asset, currencies=["GBP"])
@@ -558,10 +486,10 @@ class AccountTestCase(DataProvider, DbTransactionTestCase):
         self.account().transfer_to(self.account(), Money(50, "EUR"))
 
         src = Account.objects.filter(type=AccountType.liability).with_balances().get()
-        self.assertEqual(src.balance, Balance([Money("-110", "EUR")]))
+        self.assertEqual(src.balance, Balance([Money("110", "EUR")]))
 
         dst = Account.objects.filter(type=AccountType.expense).with_balances().get()
-        self.assertEqual(dst.balance, Balance([Money("110", "EUR")]))
+        self.assertEqual(dst.balance, Balance([Money("-110", "EUR")]))
 
     def test_with_balances_child_accounts(self):
         """Ensure with_balances() returns a valid value for child accounts"""
@@ -575,7 +503,7 @@ class AccountTestCase(DataProvider, DbTransactionTestCase):
         self.account().transfer_to(self.account(), Money(50, "EUR"))
 
         parent = Account.objects.filter(name="Parent").with_balances().get()
-        self.assertEqual(parent.balance, Balance([Money("-100", "EUR")]))
+        self.assertEqual(parent.balance, Balance([Money("100", "EUR")]))
 
     def test_with_balances_as_of(self):
         src = self.account(type=AccountType.liability)
@@ -591,7 +519,7 @@ class AccountTestCase(DataProvider, DbTransactionTestCase):
             .with_balances(as_of="2000-01-15")
             .get()
         )
-        self.assertEqual(src.balance, Balance([Money("-100", "EUR")]))
+        self.assertEqual(src.balance, Balance([Money("100", "EUR")]))
 
 
 class LegTestCase(DataProvider, DbTransactionTestCase):
@@ -797,7 +725,7 @@ class LegTestCase(DataProvider, DbTransactionTestCase):
         self.assertEqual(debit.account, src)
         self.assertEqual(credit.account, dst)
 
-    def test_account_balance_after(self):
+    def test_account_balance_after_simple(self):
         src = self.account()
         dst = self.account()
         src.transfer_to(dst, Money(100, "EUR"))
@@ -805,7 +733,7 @@ class LegTestCase(DataProvider, DbTransactionTestCase):
         src.transfer_to(dst, Money(50, "EUR"))
         dst.transfer_to(src, Money(70, "EUR"))
 
-        legs = Leg.objects.filter(account=dst).order_by("pk").all()
+        legs = Leg.objects.filter(account=src).order_by("pk").all()
         self.assertEqual(legs[0].account_balance_after(), Balance("100", "EUR"))
         self.assertEqual(legs[1].account_balance_after(), Balance("200", "EUR"))
         self.assertEqual(legs[2].account_balance_after(), Balance("250", "EUR"))
@@ -822,7 +750,7 @@ class LegTestCase(DataProvider, DbTransactionTestCase):
         src.transfer_to(dst, Money(100, "EUR"), date="2000-01-05")
         src.transfer_to(dst, Money(100, "EUR"), date="2000-01-01")
 
-        legs = Leg.objects.filter(account=dst).order_by("transaction__date").all()
+        legs = Leg.objects.filter(account=src).order_by("transaction__date").all()
         self.assertEqual(legs[0].account_balance_after(), Balance("100", "EUR"))
         self.assertEqual(legs[1].account_balance_after(), Balance("200", "EUR"))
         self.assertEqual(legs[2].account_balance_after(), Balance("250", "EUR"))
@@ -841,7 +769,7 @@ class LegTestCase(DataProvider, DbTransactionTestCase):
         src.transfer_to(dst, Money(110, "EUR"), date="2000-01-05")
         src.transfer_to(dst, Money(100, "EUR"), date="2000-01-05")
 
-        legs = Leg.objects.filter(account=dst).order_by("transaction__date").all()
+        legs = Leg.objects.filter(account=src).order_by("transaction__date").all()
         self.assertEqual(legs[0].account_balance_after(), Balance("110", "EUR"))
         self.assertEqual(legs[1].account_balance_after(), Balance("210", "EUR"))
         self.assertEqual(legs[2].account_balance_after(), Balance("260", "EUR"))
@@ -860,7 +788,7 @@ class LegTestCase(DataProvider, DbTransactionTestCase):
         src.transfer_to(dst, Money(110, "EUR"), date="2000-01-05")
         src.transfer_to(dst, Money(100, "EUR"), date="2000-01-05")
 
-        legs = Leg.objects.filter(account=dst).order_by("transaction__date").all()
+        legs = Leg.objects.filter(account=src).order_by("transaction__date").all()
         self.assertEqual(legs[0].account_balance_before(), Balance("0", "EUR"))
         self.assertEqual(legs[1].account_balance_before(), Balance("110", "EUR"))
         self.assertEqual(legs[2].account_balance_before(), Balance("210", "EUR"))
@@ -1002,17 +930,6 @@ class TestQueryAccount(DataProvider, TestCase):
 
         self.assertIn(account1, Account.objects.filter(currencies__contains=["EUR"]))
         self.assertIn(account3, Account.objects.filter(currencies__contains=["MYR"]))
-
-
-class TestCoreDeprecations(DataProvider, DbTransactionTestCase):
-    def test_transfer_to_deprecation(self):
-        src = self.account(type=AccountType.income)
-        dst = self.account(type=AccountType.asset)
-
-        with self.assertWarns(DeprecationWarning) as warning_cm:
-            src.transfer_to(dst, Money(100, "EUR"))
-
-        self.assertIn("transfer_to() has been deprecated.", str(warning_cm.warning))
 
 
 class TestLegNotMatchAccountCurrency(DataProvider, DbTransactionTestCase):

--- a/hordak/tests/test_worked_examples.py
+++ b/hordak/tests/test_worked_examples.py
@@ -66,8 +66,8 @@ class CapitalGainsTestCase(DataProvider, BalanceUtils, TestCase):
         self.assertBalanceEqual(self.income_unrealised_gain.balance(), 30000)
 
         # We sell the painting (having accurately estimated the gains in value)
-        self.income_unrealised_gain.transfer_to(
-            self.income_realised_gain, Money(30000, "EUR")
+        self.income_realised_gain.transfer_to(
+            self.income_unrealised_gain, Money(30000, "EUR")
         )
         self.painting_cost.transfer_to(self.cash, Money(100000, "EUR"))
         self.painting_unrealised_gain.transfer_to(self.cash, Money(30000, "EUR"))
@@ -133,21 +133,21 @@ class UtilityBillTestCase(DataProvider, TestCase):
 
     def test_utility_bill(self):
         # Month 1
-        self.gas_expense.transfer_to(self.gas_payable, Money(100, "EUR"))
+        self.gas_payable.transfer_to(self.gas_expense, Money(100, "EUR"))
 
         self.assertEqual(self.cash.balance(), 0)
         self.assertEqual(self.gas_expense.balance(), Balance(100, "EUR"))
         self.assertEqual(self.gas_payable.balance(), Balance(100, "EUR"))
 
         # Month 2
-        self.gas_expense.transfer_to(self.gas_payable, Money(100, "EUR"))
+        self.gas_payable.transfer_to(self.gas_expense, Money(100, "EUR"))
 
         self.assertEqual(self.cash.balance(), 0)
         self.assertEqual(self.gas_expense.balance(), Balance(200, "EUR"))
         self.assertEqual(self.gas_payable.balance(), Balance(200, "EUR"))
 
         # Month 3
-        self.gas_expense.transfer_to(self.gas_payable, Money(100, "EUR"))
+        self.gas_payable.transfer_to(self.gas_expense, Money(100, "EUR"))
 
         self.assertEqual(self.cash.balance(), 0)
         self.assertEqual(self.gas_expense.balance(), Balance(300, "EUR"))
@@ -155,7 +155,7 @@ class UtilityBillTestCase(DataProvider, TestCase):
 
         # We receive the actual bill (we are moving a negative amount of money,
         # as this is an outgoing)
-        self.cash.transfer_to(self.gas_payable, Money(-300, "EUR"))
+        self.gas_payable.transfer_to(self.cash, Money(-300, "EUR"))
 
         # We are now 300 overdrawn, but the payable account has been cleared
         self.assertEqual(self.cash.balance(), Balance(-300, "EUR"))
@@ -315,8 +315,8 @@ class CommunalHouseholdTestCase(DataProvider, BalanceUtils, TestCase):
         # the contents of those expense accounts into the relevant
         # 'Payable' accounts (as we'll need it to pay the bills when they
         # eventually arrive)
-        self.ex_elec.transfer_to(self.lia_elec_payable, Money(120 / 3, "EUR"))
-        self.ex_rates.transfer_to(self.lia_rates_payable, Money(180 / 3, "EUR"))
+        self.lia_elec_payable.transfer_to(self.ex_elec, Money(120 / 3, "EUR"))
+        self.lia_rates_payable.transfer_to(self.ex_rates, Money(180 / 3, "EUR"))
 
         # The expense accounts should now be zeroed...
         self.assertBalanceEqual(self.ex_elec.balance(), 0)

--- a/hordak/tests/views/test_transactions.py
+++ b/hordak/tests/views/test_transactions.py
@@ -42,8 +42,8 @@ class TransactionCreateViewTestCase(DataProvider, TestCase):
         response = self.client.post(
             self.view_url,
             data=dict(
-                from_account=self.bank_account.uuid,
-                to_account=self.income_account.uuid,
+                debit_account=self.bank_account.uuid,
+                credit_account=self.income_account.uuid,
                 amount_0="123.45",
                 amount_1="EUR",
                 date="2000-06-15",
@@ -52,8 +52,8 @@ class TransactionCreateViewTestCase(DataProvider, TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["Location"], "/")
-        self.assertEqual(self.bank_account.balance(), Balance("123.45", "EUR"))
-        self.assertEqual(self.income_account.balance(), Balance("123.45", "EUR"))
+        self.assertEqual(self.bank_account.balance(), Balance("-123.45", "EUR"))
+        self.assertEqual(self.income_account.balance(), Balance("-123.45", "EUR"))
 
         transaction = Transaction.objects.get()
         self.assertEqual(str(transaction.date), "2000-06-15")


### PR DESCRIPTION
As per #130 

Note that I also renamed the fields on the transaction creation form to use the terminology 'debit' and 'credit' rather than 'from' and 'to'. Hopefully that should make everything less confusing.

Note that `accounting_transfer_to()` can still be called, although it will show a deprecation warning